### PR TITLE
feat: implement useTheme hook with localStorage and system preference

### DIFF
--- a/src/hooks/useTheme/index.ts
+++ b/src/hooks/useTheme/index.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState, useCallback } from 'react'
+
+type Theme = 'light' | 'dark'
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem('theme') as Theme | null
+    if (stored === 'light' || stored === 'dark') {
+      return stored
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  })
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))
+  }, [])
+
+  return { theme, setTheme, toggleTheme }
+}


### PR DESCRIPTION
## Summary

Adds a custom `useTheme` hook to manage light and dark mode using `data-theme` on `<html>`.
Initial value respects system preference and persists the user's choice in `localStorage`
Includes a `toggleTheme` function for switching modes programmatically.

## Checklist

- [x] Functionality has been manually verified
- [ ] Tests (if applicable) are passing