### PR TITLE
feat: add UserProfile component

### DIFF
--- a/src/components/UserProfile/index.test.tsx
+++ b/src/components/UserProfile/index.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import UserProfile from '.'
+import type { GitHubUser } from '../../types'
+
+describe('<UserProfile />', () => {
+  it('shows placeholder when no user is provided', () => {
+    render(<UserProfile user={null} />)
+    expect(screen.getByText(/Search for a GitHub user above/i)).toBeInTheDocument()
+  })
+
+  it('renders all user information when user is provided', () => {
+    const user: GitHubUser = {
+      avatar_url: 'https://example.com/avatar.png',
+      name: 'Foo Bar',
+      login: 'foobar',
+      created_at: '2022-04-26T00:00:00Z',
+      bio: 'Hello world',
+      public_repos: 10,
+      followers: 20,
+      following: 5,
+      location: 'Earth',
+      twitter_username: 'foo',
+      blog: 'https://foo.com',
+      company: 'Bar Inc',
+    }
+
+    render(<UserProfile user={user} />)
+
+    // Avatar and header
+    expect(screen.getByAltText('Foo Bar avatar')).toBeInTheDocument()
+    expect(screen.getByText('Foo Bar')).toBeInTheDocument()
+    expect(screen.getByText('@foobar')).toBeInTheDocument()
+    expect(screen.getByText(/Joined 26 Apr 2022/)).toBeInTheDocument()
+
+    // Bio
+    expect(screen.getByText('Hello world')).toBeInTheDocument()
+
+    // Stats
+    expect(screen.getByText('10')).toBeInTheDocument()
+    expect(screen.getByText('20')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+
+    // Links
+    expect(screen.getByText('Earth')).toBeInTheDocument()
+    expect(screen.getByText('@foo')).toBeInTheDocument()
+    expect(screen.getByText('https://foo.com')).toBeInTheDocument()
+    expect(screen.getByText('Bar Inc')).toBeInTheDocument()
+  })
+
+  it('falls back to defaults for missing optional fields', () => {
+    const user: GitHubUser = {
+      avatar_url: '',
+      name: null,
+      login: 'nobody',
+      created_at: '2022-04-26T00:00:00Z',
+      bio: null,
+      public_repos: 0,
+      followers: 0,
+      following: 0,
+      location: null,
+      twitter_username: null,
+      blog: null,
+      company: null,
+    }
+
+    render(<UserProfile user={user} />)
+
+    expect(screen.getByText('nobody')).toBeInTheDocument()
+
+    expect(screen.getByText('This profile has no bio')).toBeInTheDocument()
+
+    const placeholders = screen.getAllByText('Not Available')
+    expect(placeholders).toHaveLength(4)
+  })
+})

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -1,0 +1,92 @@
+import { FaMapMarkerAlt, FaTwitter, FaLink, FaBuilding } from 'react-icons/fa'
+import type { GitHubUser } from '../../types'
+
+type Props = { user: GitHubUser | null }
+
+export default function UserProfile({ user }: Props) {
+  if (!user) {
+    return (
+      <div className='h-96 w-full rounded-2xl bg-secondary-bg flex items-center justify-center'>
+        <p className='text-preset-4 text-primary-text/70'>
+          Search for a GitHub user above
+        </p>
+      </div>
+    )
+  }
+
+  const joined = new Date(user.created_at).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+
+  return (
+    <div className='h-max w-full rounded-2xl bg-secondary-bg p-8 space-y-6'>
+      <div className='flex items-start gap-6'>
+        <img
+          src={user.avatar_url}
+          alt={`${user.name || user.login} avatar`}
+          className='w-24 h-24 rounded-full'
+        />
+        <div className='flex-1'>
+          <div className='w-full flex justify-between items-center mb-0.5'>
+            <h3 className='text-preset-1 text-primary-text'>
+              {user.name || user.login}
+            </h3>
+            <p className='text-preset-6 text-primary-text'>Joined {joined}</p>
+          </div>
+          <p className='text-preset-4 text-[var(--blue-300)]'>@{user.login}</p>
+        </div>
+      </div>
+
+      <p className='text-preset-4 text-primary-text/60'>
+        {user.bio || 'This profile has no bio'}
+      </p>
+
+      <div className='grid grid-cols-3 text-center bg-primary-bg rounded-lg p-6 gap-4'>
+        <div>
+          <p className='text-preset-4 text-secondary-text'>Repos</p>
+          <p className='text-preset-6 font-bold text-primary-text'>{user.public_repos}</p>
+        </div>
+        <div>
+          <p className='text-preset-4 text-secondary-text'>Followers</p>
+          <p className='text-preset-6 font-bold text-primary-text'>{user.followers}</p>
+        </div>
+        <div>
+          <p className='text-preset-4 text-secondary-text'>Following</p>
+          <p className='text-preset-6 font-bold text-primary-text'>{user.following}</p>
+        </div>
+      </div>
+
+      <div className='grid grid-cols-2 gap-4 text-preset-4'>
+        <div className='flex items-center gap-3'>
+          <FaMapMarkerAlt className={`text-tertiary-text${!user.location && '/60'}`} />
+          <span className={`text-primary-text${!user.location && '/60'}`}>{user.location || 'Not Available'}</span>
+        </div>
+        <div className='flex items-center gap-3'>
+          <FaTwitter className={`text-tertiary-text${!user.twitter_username && '/60'}`} />
+          <span className={`text-primary-text${!user.twitter_username && '/60'}`}>
+            {user.twitter_username ? `@${user.twitter_username}` : 'Not Available'}
+          </span>
+        </div>
+        <div className='flex items-center gap-3'>
+          <FaLink className={`text-tertiary-text${!user.blog && '/60'}`} />
+          <a
+            href={user.blog || undefined}
+            target='_blank'
+            rel='noopener noreferrer'
+            className={`${
+              user.blog ? 'text-primary-text hover:underline' : 'text-primary-text/60'
+            }`}
+          >
+            {user.blog || 'Not Available'}
+          </a>
+        </div>
+        <div className='flex items-center gap-3'>
+          <FaBuilding className={`text-tertiary-text${!user.company && '/60'}`} />
+          <span className={`text-primary-text${!user.company && '/60'}`}>{user.company || 'Not Available'}</span>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Add `UserProfile` component to display GitHub user data or a placeholder when no user is provided.  
- Shows avatar, name/login, join date, bio, repo/follower stats, and links (location, Twitter, blog, company) with fallbacks.

## Checklist

- [x] Functionality has been manually verified  
- [ ] Tests (if applicable) are passing
