### PR TITLE
chore: remove default vite favicon link

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary

Remove the default Vite favicon (`/vite.svg`) reference from the HTML, since i'm not using it.

## Checklist

- [x] Functionality has been manually verified  
- [ ] Tests (if applicable) are passing
